### PR TITLE
fix home route

### DIFF
--- a/packages/themes/default/components/Layout.svelte
+++ b/packages/themes/default/components/Layout.svelte
@@ -30,8 +30,9 @@
 	function set_active_link(node){
 		return {
 			destroy: current_page.subscribe(page => {
+				const url = page.url || '/';
 				node.querySelectorAll('a').forEach(a => {
-				if(a.getAttribute('href') === page.url)
+				if(a.getAttribute('href') === url)
 					a.classList.add('active');
 				else
 					a.classList.remove('active')


### PR DESCRIPTION
It seems like when we have the URL path "/", it gets stripped to "" which doesn't get properly detected by https://github.com/AlexxNB/svelte-docs/blob/7c68ab65d72eb8b969e3d9ec97f1b595f1bed22a/packages/themes/default/components/Layout.svelte#L34

Before:
![Screen Shot 2020-05-21 at 5 10 10 am](https://user-images.githubusercontent.com/1149825/82487211-6ccfb880-9b21-11ea-80dd-c4f5e30cb608.png)

After:
![Screen Shot 2020-05-21 at 5 10 30 am](https://user-images.githubusercontent.com/1149825/82487226-72c59980-9b21-11ea-8a86-1a440f47f67a.png)

Hope you find this helpful, let me know if it's good otherwise I can find an alternative fix.