### PR TITLE
add allow-same-origin

### DIFF
--- a/packages/core/builtins/Example/Example.svelte
+++ b/packages/core/builtins/Example/Example.svelte
@@ -49,7 +49,7 @@
         title="Result"
         scrolling="no"
         bind:this={iframe}
-        sandbox="allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals allow-scripts"
+        sandbox="allow-same-origin allow-popups-to-escape-sandbox allow-scripts allow-popups allow-forms allow-pointer-lock allow-top-navigation allow-modals allow-scripts"
         {srcdoc}
     ></iframe>
      <pre slot="code" class="hljs"><code>{@html code.trim()}</code></pre>


### PR DESCRIPTION
I'm getting this error when trying to access `sessionStorage` inside the iframe.

```
Uncaught DOMException: Failed to read the 'sessionStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.
```

I don't see any security risk as this is under a controlled environment. Cheers.